### PR TITLE
Support for Python 3.7+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         experimental: [false]
     defaults:
       run:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [Ubuntu, MacOS, Windows]
-        python-version: ["3.10"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
         experimental: [false]
     defaults:
       run:

--- a/openskill/rate.py
+++ b/openskill/rate.py
@@ -37,10 +37,10 @@ class Rating:
                 return True
             else:
                 return False
-        elif isinstance(other, Union[list, tuple]):
+        elif isinstance(other, (list, tuple)):
             if len(other) == 2:
                 for value in other:
-                    if not isinstance(value, Union[int, float]):
+                    if not isinstance(value, (int, float)):
                         raise ValueError(
                             f"The {other.__class__.__name__} contains an "
                             f"element '{value}' of type '{value.__class__.__name__}'"
@@ -68,10 +68,10 @@ def ordinal(agent: Union[Rating, list, tuple], **options) -> float:
     :param options: Pass in a set of custom values for constants defined in the Weng-Lin paper.
     :return: A :class:`~float` object that represents a 1 dimensional value for a rating.
     """
-    if isinstance(agent, Union[list, tuple]):
+    if isinstance(agent, (list, tuple)):
         if len(agent) == 2:
             for value in agent:
-                if not isinstance(value, Union[int, float]):
+                if not isinstance(value, (int, float)):
                     raise ValueError(
                         f"The {agent.__class__.__name__} contains an "
                         f"element '{value}' of type '{value.__class__.__name__}'"
@@ -103,7 +103,7 @@ def create_rating(rating_list: List[Union[int, float]]) -> Rating:
         raise TypeError("Argument is already a 'Rating' object.")
     elif len(rating_list) == 2:
         for value in rating_list:
-            if not isinstance(value, Union[int, float]):
+            if not isinstance(value, (int, float)):
                 raise ValueError(
                     f"The {rating_list.__class__.__name__} contains an "
                     f"element '{value}' of type '{value.__class__.__name__}'"

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ keywords =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
 	scipy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ keywords =
 
 [options]
 packages = find:
-python_requires = >=3.10
+python_requires = >=3.6
 install_requires =
 	scipy
 


### PR DESCRIPTION
I've been using openskill in my local Python 3.9 environment for a while now. I've been liking it a lot and I wanted to add it to one of my projects for use in production. I was surprised to find that the latest version on pypi said it only supported 3.10+, which is pretty rough from a compatibility perspective. I wanted to check how much it _actually_ depended on features in 3.10, so I switched to a 3.6 virtual env and tried running the tests. They failed, and indicated that `isinstance(var, Union[T1, T2])` calls were an issue. This is a fairly easy thing to express in older pythons with: `isinstance(var, (T1, T2))`. I did a search and replace on these, and then the tests passed. That was the only incompatibility I could find.

If the maintainers are open to supporting older Pythons for a new release, that would be very helpful to me. I would also be OK with the minimum version being something like 3.7 or 3.8.

I haven't used towncrier before, and it wasn't immediately obvious how to impute the changelog, so I figure I'll wait until a maintainer greenlights this before I continue any work on details like that. 

### Affirmation

-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA256

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under openskill.py's MIT license.

I certify the above statement is true and correct: Erotemic
-----BEGIN PGP SIGNATURE-----

iHUEARYIAB0WIQT3wcl6TvLPlkPZTGZswF8VWxKrNgUCYnUyfgAKCRBswF8VWxKr
Nv5kAQCy8UMZZYCX3+dG5sLn1UmF/SZ1qnGwsMAUWsVgTdJvFAEAzOCgQwWOpIma
wPXZMrEOpp8S9IAgNpeFetms+kp9lQ0=
=7IXK
-----END PGP SIGNATURE-----