### PR TITLE
Fix ranking calculation for ties.

### DIFF
--- a/changes/174.bugfix.rst
+++ b/changes/174.bugfix.rst
@@ -1,0 +1,1 @@
+Fix rank calculation for ties.

--- a/openskill/models/weng_lin/bradley_terry_full.py
+++ b/openskill/models/weng_lin/bradley_terry_full.py
@@ -1071,7 +1071,7 @@ class BradleyTerryFull:
         if ranks:
             team_scores = []
             for index, _ in enumerate(game):
-                team_scores.append(ranks[index] or index)
+                team_scores.append(ranks[index] if ranks[index] is not None else index)
         else:
             team_scores = [i for i, _ in enumerate(game)]
 

--- a/openskill/models/weng_lin/bradley_terry_part.py
+++ b/openskill/models/weng_lin/bradley_terry_part.py
@@ -1067,7 +1067,7 @@ class BradleyTerryPart:
         if ranks:
             team_scores = []
             for index, _ in enumerate(game):
-                team_scores.append(ranks[index] or index)
+                team_scores.append(ranks[index] if ranks[index] is not None else index)
         else:
             team_scores = [i for i, _ in enumerate(game)]
 

--- a/openskill/models/weng_lin/plackett_luce.py
+++ b/openskill/models/weng_lin/plackett_luce.py
@@ -1132,7 +1132,7 @@ class PlackettLuce:
         if ranks:
             team_scores = []
             for index, _ in enumerate(game):
-                team_scores.append(ranks[index] or index)
+                team_scores.append(ranks[index] if ranks[index] is not None else index)
         else:
             team_scores = [i for i, _ in enumerate(game)]
 

--- a/openskill/models/weng_lin/thurstone_mosteller_full.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_full.py
@@ -1119,7 +1119,7 @@ class ThurstoneMostellerFull:
         if ranks:
             team_scores = []
             for index, _ in enumerate(game):
-                team_scores.append(ranks[index] or index)
+                team_scores.append(ranks[index] if ranks[index] is not None else index)
         else:
             team_scores = [i for i, _ in enumerate(game)]
 

--- a/openskill/models/weng_lin/thurstone_mosteller_part.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_part.py
@@ -1110,7 +1110,7 @@ class ThurstoneMostellerPart:
         if ranks:
             team_scores = []
             for index, _ in enumerate(game):
-                team_scores.append(ranks[index] or index)
+                team_scores.append(ranks[index] if ranks[index] is not None else index)
         else:
             team_scores = [i for i, _ in enumerate(game)]
 

--- a/tests/models/weng_lin/test_common.py
+++ b/tests/models/weng_lin/test_common.py
@@ -81,7 +81,7 @@ def test_calculate_rankings(model) -> None:
     assert model._calculate_rankings([]) == []
     assert model._calculate_rankings([], []) == []
     assert model._calculate_rankings([a, b, c, d]) == [0, 1, 2, 3]
-    assert model._calculate_rankings([a, b], [0, 0]) == [0, 1]
+    assert model._calculate_rankings([a, b], [0, 0]) == [0, 0]
     assert model._calculate_rankings([a, b, c, d], [1, 2, 3, 4]) == [0, 1, 2, 3]
     assert model._calculate_rankings([a, b, c, d], [1, 1, 3, 4]) == [0, 0, 2, 3]
     assert model._calculate_rankings([a, b, c, d], [1, 2, 3, 3]) == [0, 1, 2, 2]
@@ -201,3 +201,24 @@ def test_ladder_pairs():
     assert _ladder_pairs([1, 2]) == [[2], [1]]
     assert _ladder_pairs([1, 2, 3]) == [[2], [1, 3], [2]]
     assert _ladder_pairs([1, 2, 3, 4]) == [[2], [1, 3], [2, 4], [3]]
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("tie_score", [-1, 0, 0.1, 10, 13.4])
+def test_ties(model, tie_score):
+    model_instance = model()
+
+    player_1 = model_instance.rating()
+    player_2 = model_instance.rating()
+
+    result = model_instance.rate(
+        [[player_1], [player_2]], scores=[tie_score, tie_score]
+    )
+
+    # Both players should have the same rating change
+    assert (
+        result[0][0].mu == result[1][0].mu
+    ), f"Model {model.__name__} with score {tie_score}: Players should have equal mu after tie"
+    assert (
+        result[0][0].sigma == result[1][0].sigma
+    ), f"Model {model.__name__} with score {tie_score}: Players should have equal sigma after tie"


### PR DESCRIPTION
## Description of Changes

- `0` is treated as "falsy" by python, this results in an incorrect ranking calculation in `model._calculate_rankings()`
- Wrote a test to ensure draws between players with the same rating do not affect `mu`

### Issue(s) Resolved


Fixes #173 


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under openskill.py's MIT license.


I certify the above statement is true and correct: xelandernt


