### PR TITLE
fix: rate() no longer mutates model.limit_sigma on each call

### DIFF
--- a/openskill/models/weng_lin/bradley_terry_full.py
+++ b/openskill/models/weng_lin/bradley_terry_full.py
@@ -640,10 +640,9 @@ class BradleyTerryFull:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/openskill/models/weng_lin/bradley_terry_part.py
+++ b/openskill/models/weng_lin/bradley_terry_part.py
@@ -646,10 +646,9 @@ class BradleyTerryPart:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/openskill/models/weng_lin/plackett_luce.py
+++ b/openskill/models/weng_lin/plackett_luce.py
@@ -641,10 +641,9 @@ class PlackettLuce:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/openskill/models/weng_lin/thurstone_mosteller_full.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_full.py
@@ -661,10 +661,9 @@ class ThurstoneMostellerFull:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/openskill/models/weng_lin/thurstone_mosteller_part.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_part.py
@@ -667,10 +667,9 @@ class ThurstoneMostellerPart:
         # Possible Final Result
         final_result = processed_result
 
-        if limit_sigma is not None:
-            self.limit_sigma = limit_sigma
+        _limit_sigma = limit_sigma if limit_sigma is not None else self.limit_sigma
 
-        if self.limit_sigma:
+        if _limit_sigma:
             final_result = []
 
             # Reuse processed_result

--- a/tests/models/weng_lin/test_bradley_terry_full.py
+++ b/tests/models/weng_lin/test_bradley_terry_full.py
@@ -462,6 +462,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]

--- a/tests/models/weng_lin/test_bradley_terry_part.py
+++ b/tests/models/weng_lin/test_bradley_terry_part.py
@@ -482,6 +482,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]

--- a/tests/models/weng_lin/test_plackett_luce.py
+++ b/tests/models/weng_lin/test_plackett_luce.py
@@ -460,6 +460,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]

--- a/tests/models/weng_lin/test_thurstone_mosteller_full.py
+++ b/tests/models/weng_lin/test_thurstone_mosteller_full.py
@@ -469,6 +469,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]

--- a/tests/models/weng_lin/test_thurstone_mosteller_part.py
+++ b/tests/models/weng_lin/test_thurstone_mosteller_part.py
@@ -490,6 +490,12 @@ def test_rate_errors() -> None:
     assert winner.sigma <= a.sigma
     assert loser.sigma <= b.sigma
 
+    # Ensures limit_sigma passed to rate() does not mutate the model instance
+    a = r()
+    b = r()
+    model.rate([[a], [b]], limit_sigma=True)
+    assert model.limit_sigma is False
+
     # Test ValueError
     team_1 = [r()]
     team_2 = [r(), r()]


### PR DESCRIPTION
this is almost a nit, but i think in the interest of code quality, it's worth handling.


## Description of Changes

* [x] limit_sigma on the model is no longer mutated by a call to `rate()`
* [x] Added test(s) covering the changes (if testable)


### Issue(s) Resolved

limit_sigma carries over between calls because it mutates self.limit_sigma, so the model object holds onto that in its state for future calls. in my opinion, i don't think this was intentional. this is a really subtle edge case, but i think it helps the ergonomics of what the user might expect when they call us.


### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under openskill.py's MIT license.


I certify the above statement is true and correct: philihp