### PR TITLE
fix: respect tau=0 in rate()

### DIFF
--- a/openskill/models/weng_lin/bradley_terry_full.py
+++ b/openskill/models/weng_lin/bradley_terry_full.py
@@ -583,7 +583,7 @@ class BradleyTerryFull:
         teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
-        tau = tau if tau else self.tau
+        tau = tau if tau is not None else self.tau
         tau_squared = tau * tau
         for team_index, team in enumerate(teams):
             for player_index, player in enumerate(team):

--- a/openskill/models/weng_lin/bradley_terry_part.py
+++ b/openskill/models/weng_lin/bradley_terry_part.py
@@ -589,7 +589,7 @@ class BradleyTerryPart:
         teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
-        tau = tau if tau else self.tau
+        tau = tau if tau is not None else self.tau
         tau_squared = tau * tau
         for team_index, team in enumerate(teams):
             for player_index, player in enumerate(team):

--- a/openskill/models/weng_lin/plackett_luce.py
+++ b/openskill/models/weng_lin/plackett_luce.py
@@ -584,7 +584,7 @@ class PlackettLuce:
         teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
-        tau = tau if tau else self.tau
+        tau = tau if tau is not None else self.tau
         tau_squared = tau * tau
         for team_index, team in enumerate(teams):
             for player_index, player in enumerate(team):

--- a/openskill/models/weng_lin/thurstone_mosteller_full.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_full.py
@@ -604,7 +604,7 @@ class ThurstoneMostellerFull:
         teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
-        tau = tau if tau else self.tau
+        tau = tau if tau is not None else self.tau
         tau_squared = tau * tau
         for team_index, team in enumerate(teams):
             for player_index, player in enumerate(team):

--- a/openskill/models/weng_lin/thurstone_mosteller_part.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_part.py
@@ -610,7 +610,7 @@ class ThurstoneMostellerPart:
         teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
-        tau = tau if tau else self.tau
+        tau = tau if tau is not None else self.tau
         tau_squared = tau * tau
         for team_index, team in enumerate(teams):
             for player_index, player in enumerate(team):

--- a/tests/models/weng_lin/test_bradley_terry_full.py
+++ b/tests/models/weng_lin/test_bradley_terry_full.py
@@ -635,3 +635,20 @@ def test_weight_bounds_none_disables_normalization() -> None:
     mu_changes = [r.mu - 25.0 for r in result[0]]
     assert mu_changes[0] == pytest.approx(mu_changes[1])
     assert mu_changes[1] == pytest.approx(mu_changes[2])
+
+
+def test_rate_tau_zero_is_respected() -> None:
+    """
+    Passing tau=0 must suppress sigma inflation entirely.
+    Before the fix, tau=0 was falsy and fell back to self.tau,
+    making it indistinguishable from not passing tau at all.
+    """
+    model = BradleyTerryFull(tau=0.3)
+    a = model.rating()
+    b = model.rating()
+
+    [[w_zero], [l_zero]] = model.rate([[a], [b]], tau=0)
+    [[w_default], [l_default]] = model.rate([[a], [b]])
+
+    assert w_zero.sigma <= w_default.sigma
+    assert l_zero.sigma <= l_default.sigma

--- a/tests/models/weng_lin/test_bradley_terry_part.py
+++ b/tests/models/weng_lin/test_bradley_terry_part.py
@@ -655,3 +655,20 @@ def test_weight_bounds_none_disables_normalization() -> None:
     mu_changes = [r.mu - 25.0 for r in result[0]]
     assert mu_changes[0] == pytest.approx(mu_changes[1])
     assert mu_changes[1] == pytest.approx(mu_changes[2])
+
+
+def test_rate_tau_zero_is_respected() -> None:
+    """
+    Passing tau=0 must suppress sigma inflation entirely.
+    Before the fix, tau=0 was falsy and fell back to self.tau,
+    making it indistinguishable from not passing tau at all.
+    """
+    model = BradleyTerryPart(tau=0.3)
+    a = model.rating()
+    b = model.rating()
+
+    [[w_zero], [l_zero]] = model.rate([[a], [b]], tau=0)
+    [[w_default], [l_default]] = model.rate([[a], [b]])
+
+    assert w_zero.sigma <= w_default.sigma
+    assert l_zero.sigma <= l_default.sigma

--- a/tests/models/weng_lin/test_plackett_luce.py
+++ b/tests/models/weng_lin/test_plackett_luce.py
@@ -638,3 +638,22 @@ def test_weight_bounds_none_disables_normalization() -> None:
     mu_changes = [r.mu - 25.0 for r in result[0]]
     assert mu_changes[0] == pytest.approx(mu_changes[1])
     assert mu_changes[1] == pytest.approx(mu_changes[2])
+
+
+def test_rate_tau_zero_is_respected() -> None:
+    """
+    Passing tau=0 must suppress sigma inflation entirely.
+    Before the fix, tau=0 was falsy and fell back to self.tau,
+    making it indistinguishable from not passing tau at all.
+    """
+    model = PlackettLuce(tau=0.3)
+    a = model.rating()
+    b = model.rating()
+
+    [[w_zero], [l_zero]] = model.rate([[a], [b]], tau=0)
+    [[w_default], [l_default]] = model.rate([[a], [b]])
+
+    # With tau=0 there is no additive sigma inflation, so resulting sigmas
+    # must be strictly less than or equal to those with tau=0.3.
+    assert w_zero.sigma <= w_default.sigma
+    assert l_zero.sigma <= l_default.sigma

--- a/tests/models/weng_lin/test_thurstone_mosteller_full.py
+++ b/tests/models/weng_lin/test_thurstone_mosteller_full.py
@@ -642,3 +642,20 @@ def test_weight_bounds_none_disables_normalization() -> None:
     mu_changes = [r.mu - 25.0 for r in result[0]]
     assert mu_changes[0] == pytest.approx(mu_changes[1])
     assert mu_changes[1] == pytest.approx(mu_changes[2])
+
+
+def test_rate_tau_zero_is_respected() -> None:
+    """
+    Passing tau=0 must suppress sigma inflation entirely.
+    Before the fix, tau=0 was falsy and fell back to self.tau,
+    making it indistinguishable from not passing tau at all.
+    """
+    model = ThurstoneMostellerFull(tau=0.3)
+    a = model.rating()
+    b = model.rating()
+
+    [[w_zero], [l_zero]] = model.rate([[a], [b]], tau=0)
+    [[w_default], [l_default]] = model.rate([[a], [b]])
+
+    assert w_zero.sigma <= w_default.sigma
+    assert l_zero.sigma <= l_default.sigma

--- a/tests/models/weng_lin/test_thurstone_mosteller_part.py
+++ b/tests/models/weng_lin/test_thurstone_mosteller_part.py
@@ -663,3 +663,20 @@ def test_weight_bounds_none_disables_normalization() -> None:
     mu_changes = [r.mu - 25.0 for r in result[0]]
     assert mu_changes[0] == pytest.approx(mu_changes[1])
     assert mu_changes[1] == pytest.approx(mu_changes[2])
+
+
+def test_rate_tau_zero_is_respected() -> None:
+    """
+    Passing tau=0 must suppress sigma inflation entirely.
+    Before the fix, tau=0 was falsy and fell back to self.tau,
+    making it indistinguishable from not passing tau at all.
+    """
+    model = ThurstoneMostellerPart(tau=0.3)
+    a = model.rating()
+    b = model.rating()
+
+    [[w_zero], [l_zero]] = model.rate([[a], [b]], tau=0)
+    [[w_default], [l_default]] = model.rate([[a], [b]])
+
+    assert w_zero.sigma <= w_default.sigma
+    assert l_zero.sigma <= l_default.sigma


### PR DESCRIPTION
## Description of Changes

* [x] check for tau is None
* [x] added tests which would expose this regression in the future


### Issue(s) Resolved

tau=0 is a valid value meaning "no sigma inflation this call", but the falsy check `tau if tau else self.tau` treated 0 identically to None, silently falling back to the model default.



### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under openskill.py's MIT license.

I certify the above statement is true and correct: philihp